### PR TITLE
Add Command to Wipe Events and Orgs Tables

### DIFF
--- a/app/Console/Commands/ClearOrgsAndEvents.php
+++ b/app/Console/Commands/ClearOrgsAndEvents.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use DateInterval;
+use DateTimeInterface;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Isolatable;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class ClearOrgsAndEvents extends Command implements Isolatable
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:clear-orgs-and-events';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clears out the events and orgs tables for debugging purposes.';
+
+    /*
+     * Lock timeout for the command.
+     */
+    public function isolationLockExpiresAt(): DateTimeInterface|DateInterval
+    {
+        return now()->addMinutes(1);
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $models_to_reset = [
+            "Events" => "App\Models\Event",
+            "Orgs" => "App\Models\Org"
+        ];
+
+        ProgressBar::setFormatDefinition('simplified', '%current% of %max% tables wiped --- %message%');
+        $progressIndicator = $this->output->createProgressBar(sizeof($models_to_reset));
+        $progressIndicator->setFormat('simplified');
+
+        $progressIndicator->start();
+
+        foreach ($models_to_reset as $model_name => $model_namespace) {
+            $progressIndicator->setMessage("Resetting " . $model_name);
+            $model_namespace::truncate();
+            $progressIndicator->advance();
+        }
+
+        $progressIndicator->setMessage("Events and Orgs have been successfully wiped.");
+        $progressIndicator->finish();
+    }
+}

--- a/tests/Feature/ClearOrgsAndEventsTest.php
+++ b/tests/Feature/ClearOrgsAndEventsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Console\Commands\ClearOrgsAndEvents;
+use App\Models\Event;
+use App\Models\Org;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('wipes the events and orgs tables', function () {
+    $expected_count = 10;
+
+    // This will also create 10 orgs
+    Event::factory()->count($expected_count)->create();
+
+    // Check pre-wipe count
+    expect(Event::count())->toEqual($expected_count);
+    expect(Org::count())->toEqual($expected_count);
+
+
+    Artisan::call(ClearOrgsAndEvents::class);
+
+    // Ensure tables are squeaky clean
+    expect(Event::count())->toEqual(0);
+    expect(Org::count())->toEqual(0);
+});


### PR DESCRIPTION
# Summary
Allows use of `php artisan app:clear-orgs-and-events` to truncate the `events` and `orgs` tables.